### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bin/ddbroker.py
+++ b/bin/ddbroker.py
@@ -93,7 +93,7 @@ if '__main__' == __name__:
     args_list = parser.parse_args()
     numeric_level = getattr(logging, args_list.loglevel.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError('Invalid log level: %s' % args_list.loglevel)
+        raise ValueError('Invalid log level: {0!s}'.format(args_list.loglevel))
 
     if args_list.verbose:
         logging.warning("Verbose option is deprecated, use loglevel instead")

--- a/bin/ddclient.py
+++ b/bin/ddclient.py
@@ -65,7 +65,7 @@ class SecureCli(ClientSafe):
 
     def add_msg(self, msg):
         st = datetime.datetime.fromtimestamp(time.time()).strftime('%H:%M:%S')
-        self.msg_list.append("%s:%s" % (st, msg))
+        self.msg_list.append("{0!s}:{1!s}".format(st, msg))
         self.messages = ""
 
         for n in self.msg_list:
@@ -73,7 +73,7 @@ class SecureCli(ClientSafe):
         self.body[-1].set_text(self.messages)
 
     def on_data(self, src, msg):
-        self.add_msg("DATA from %s: %s" % (str(src), str(msg)))
+        self.add_msg("DATA from {0!s}: {1!s}".format(str(src), str(msg)))
 
     def on_reg(self):
         self.registered = True
@@ -85,16 +85,16 @@ class SecureCli(ClientSafe):
 
     def on_error(self, code, msg):
         if code == ClientSafe.E_REGFAIL:
-            self.add_msg("ERROR - Registration failed, reason: %s" % msg[0])
+            self.add_msg("ERROR - Registration failed, reason: {0!s}".format(msg[0]))
         elif code == ClientSafe.E_VERSION:
             self.add_msg("ERROR - Registration failed, wrong protcol version!")
         elif code == ClientSafe.E_NODST:
-            self.add_msg("ERROR - No destination: %s"%msg)
+            self.add_msg("ERROR - No destination: {0!s}".format(msg))
         else:
-            self.add_msg("ERROR - unknwon (%d,%s)"%(code,msg))
+            self.add_msg("ERROR - unknwon ({0:d},{1!s})".format(code, msg))
 
     def on_pub(self, src, topic, msg):
-        msgstr = "PUB %s from %s: %s" % (str(topic), str(src), str(msg))
+        msgstr = "PUB {0!s} from {1!s}: {2!s}".format(str(topic), str(src), str(msg))
         self.add_msg(msgstr)
 
     def update_main_text(self):
@@ -105,7 +105,7 @@ class SecureCli(ClientSafe):
 
         substr = json.dumps(self.subscriptions)
         self.main_text = (
-            "DoubleDecker %s Dealer: %s State: %s\nSubscriptions: %s" % (
+            "DoubleDecker {0!s} Dealer: {1!s} State: {2!s}\nSubscriptions: {3!s}".format(
                 self._name.decode(), self._dealerurl.decode(), state, substr))
         try:
             self.body[0].set_text(self.main_text)
@@ -229,15 +229,15 @@ class SecureCli(ClientSafe):
             self.publish(self.pub_topic, self.pub_msg)
 
         if cmd == 'subscribe' :
-            substr = "%s/%s" % (self.sub_topic, self.sub_scope)
+            substr = "{0!s}/{1!s}".format(self.sub_topic, self.sub_scope)
             self.subscriptions.append(substr)
             try :
                 self.subscribe(self.sub_topic, self.sub_scope)
             except BaseException as e:
-                self.add_msg("Exception caught : %s)" % str(e))
+                self.add_msg("Exception caught : {0!s})".format(str(e)))
 
         if cmd == 'unsubscribe':
-            substr = "%s/%s" % (self.sub_topic, self.sub_scope)
+            substr = "{0!s}/{1!s}".format(self.sub_topic, self.sub_scope)
             self.subscriptions.remove(substr)
             self.unsubscribe(self.unsub_topic,self.unsub_scope)
 
@@ -256,7 +256,7 @@ class PlainCli(ClientUnsafe):
         super().__init__(name, dealerurl, customer)
 
     def on_data(self, src, msg):
-        logging.info("Got message from %s: %s" % (str(src), str(msg)))
+        logging.info("Got message from {0!s}: {1!s}".format(str(src), str(msg)))
 
     def on_reg(self):
         logging.info('Registered, subscribing to customer topic "test-topic/all"')
@@ -274,7 +274,7 @@ class PlainCli(ClientUnsafe):
         logging.info('Lost connection to broker')
 
     def on_pub(self, src, topic, msg):
-        logging.info("Got message on topic %s from %s: %s" % (str(topic), str(src), str(msg)))
+        logging.info("Got message on topic {0!s} from {1!s}: {2!s}".format(str(topic), str(src), str(msg)))
 
 
     def on_exit_clicked(button):
@@ -320,7 +320,7 @@ if __name__ == '__main__':
 
     numeric_level = getattr(logging, args.loglevel.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError('Invalid log level: %s' % args.loglevel)
+        raise ValueError('Invalid log level: {0!s}'.format(args.loglevel))
     if args.logfile:
         logging.basicConfig(format='%(levelname)s:%(message)s', filename=args.logfile, level=numeric_level)
     else:

--- a/bin/jsonclient.py
+++ b/bin/jsonclient.py
@@ -105,7 +105,7 @@ class SecureCli(ClientSafe):
             elif res['type'] == "sub":
                 self.subscribe(res['topc'],res['scope'])
             else:
-                print(json.dumps({"type":"error", "data":"Command '%s' not implemented"%res['type']}))
+                print(json.dumps({"type":"error", "data":"Command '{0!s}' not implemented".format(res['type'])}))
         else:
             print(json.dumps({"type":"error", "data":"Couldn't parse JSON"}))
 
@@ -165,7 +165,7 @@ if __name__ == '__main__':
 
     numeric_level = getattr(logging, args.loglevel.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError('Invalid log level: %s' % args.loglevel)
+        raise ValueError('Invalid log level: {0!s}'.format(args.loglevel))
     if args.logfile:
         logging.basicConfig(format='%(levelname)s:%(message)s', filename=args.logfile, level=numeric_level)
     else:

--- a/bin/socket_client.py
+++ b/bin/socket_client.py
@@ -78,7 +78,7 @@ class SecureCli(ClientSafe):
     # callback called automatically everytime a point to point is sent at
     # destination to the current client
     def on_data(self, src, msg):
-        print("DATA from %s: %s" % (str(src), str(msg)))
+        print("DATA from {0!s}: {1!s}".format(str(src), str(msg)))
         if len(msg) < 2:
             logging.error("Message received but contains only two frames")
             return
@@ -104,12 +104,12 @@ class SecureCli(ClientSafe):
 
     # callback called when the client receives an error message
     def on_error(self, code, msg):
-        print("ERROR n#%d : %s" % (code, msg))
+        print("ERROR n#{0:d} : {1!s}".format(code, msg))
 
     # callback called when the client receives a message on a topic he
     # subscribed to previously
     def on_pub(self, src, topic, msg):
-        print("PUB %s from %s: %s" % (str(topic), str(src), str(msg)))
+        print("PUB {0!s} from {1!s}: {2!s}".format(str(topic), str(src), str(msg)))
 
     def start(self):
         self.serverThread.start()
@@ -166,7 +166,7 @@ if __name__ == '__main__':
 
     numeric_level = getattr(logging, args.loglevel.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError('Invalid log level: %s' % args.loglevel)
+        raise ValueError('Invalid log level: {0!s}'.format(args.loglevel))
 
     logging.basicConfig(format='%(levelname)s:%(message)s', filename=args.logfile, level=numeric_level)
 

--- a/bin/template_client.py
+++ b/bin/template_client.py
@@ -41,7 +41,7 @@ class SecureCli(ClientSafe):
     # callback called automatically everytime a point to point is sent at
     # destination to the current client
     def on_data(self, src, msg):
-        print("DATA from %s: %s" % (str(src), str(msg)))
+        print("DATA from {0!s}: {1!s}".format(str(src), str(msg)))
 
     # callback called upon registration of the client with its broker
     def on_reg(self):
@@ -74,12 +74,12 @@ class SecureCli(ClientSafe):
 
     # callback called when the client receives an error message
     def on_error(self, code, msg):
-        print("ERROR n#%d : %s" % (code, msg))
+        print("ERROR n#{0:d} : {1!s}".format(code, msg))
 
     # callback called when the client receives a message on a topic he
     # subscribed to previously
     def on_pub(self, src, topic, msg):
-        print("PUB %s from %s: %s" % (str(topic), str(src), str(msg)))
+        print("PUB {0!s} from {1!s}: {2!s}".format(str(topic), str(src), str(msg)))
 
 
 if __name__ == '__main__':
@@ -115,7 +115,7 @@ if __name__ == '__main__':
 
     numeric_level = getattr(logging, args.loglevel.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError('Invalid log level: %s' % args.loglevel)
+        raise ValueError('Invalid log level: {0!s}'.format(args.loglevel))
 
     logging.basicConfig(format='%(levelname)s:%(message)s', filename=args.logfile, level=numeric_level)
 

--- a/doubledecker/broker.py
+++ b/doubledecker/broker.py
@@ -72,7 +72,7 @@ class Broker(object, metaclass=abc.ABCMeta):
         self.tenants = list()
         self.state = DD.S_ROOT
         self.name = name
-        self.rname = ("|%s|" % name.decode()).encode()
+        self.rname = ("|{0!s}|".format(name.decode())).encode()
         self.timeout = 0
         self.pub_southub = True
         self.random_number = 0
@@ -146,8 +146,8 @@ class Broker(object, metaclass=abc.ABCMeta):
                 #logging.debug("routerurl split %s" % url)
                 self.router.bind(url)
         except zmq.error.ZMQError as e:
-            logging.critical('An error happened durind the binding of' % self.routerurl)
-            logging.critical('Error says :' % e.strerror)
+            logging.critical('An error happened durind the binding of'.format(*self.routerurl))
+            logging.critical('Error says :'.format(*e.strerror))
             self.shutdown()
             return
 
@@ -174,11 +174,11 @@ class Broker(object, metaclass=abc.ABCMeta):
                     #logging.debug("Port number: %s" % port)
                     pubport = int(port) + 1
                     subport = int(port) + 2
-                    self.pub_southurl = url.replace(port, "%d" % pubport)
-                    self.sub_southurl = url.replace(port, "%d" % subport)
+                    self.pub_southurl = url.replace(port, "{0:d}".format(pubport))
+                    self.sub_southurl = url.replace(port, "{0:d}".format(subport))
                     #logging.debug("pub and sub strings: %s %s" % (self.pub_southurl, self.sub_southurl))
                 elif 'ipc' in url:
-                    logging.debug("IPC: %s" % url.split(':')[-1])
+                    logging.debug("IPC: {0!s}".format(url.split(':')[-1]))
                 else:
                     logging.warning("routerurl is not tcp or ipc, pub/sub not supported!")
 
@@ -188,8 +188,8 @@ class Broker(object, metaclass=abc.ABCMeta):
                 for url in self.pub_southurl.split(','):
                     self.pub_south_sock.bind(url)
             except zmq.error.ZMQError as e:
-                logging.critical('PublisherS: error happened during the binding of %s' % url)
-                logging.critical('Error says : %s' % e.strerror)
+                logging.critical('PublisherS: error happened during the binding of {0!s}'.format(url))
+                logging.critical('Error says : {0!s}'.format(e.strerror))
                 self.shutdown()
                 return
             self.pub_south_stream.on_recv(self.on_pub_south_msg, self.IOLoop)
@@ -200,22 +200,21 @@ class Broker(object, metaclass=abc.ABCMeta):
 
                 self.sub_south_stream.on_recv(self.on_sub_south_msg)
             except zmq.error.ZMQError as e:
-                logging.critical('SubscriberS: error happened during the binding of %s' % url)
-                logging.critical('Error says : %s' % e.strerror)
+                logging.critical('SubscriberS: error happened during the binding of {0!s}'.format(url))
+                logging.critical('Error says : {0!s}'.format(e.strerror))
                 self.shutdown()
                 return
 
-        logging.info("Configured: name = %s, Router = %s" %
-                     (self.name, self.routerurl))
+        logging.info("Configured: name = {0!s}, Router = {1!s}".format(self.name, self.routerurl))
         if self.dealerurl == '':
             logging.info('configured as root of the architecture')
         else:
-            logging.info('dealer : %s' % self.dealerurl)
+            logging.info('dealer : {0!s}'.format(self.dealerurl))
 
         # Configure scope
         try:
             self.scopearray = self.scope.split('/')
-            logging.info('Scope: %s' % self.scope)
+            logging.info('Scope: {0!s}'.format(self.scope))
         except:
             logging.critical("Error: The scope should be given as '1/2/3'")
             self.shutdown()
@@ -249,8 +248,7 @@ class Broker(object, metaclass=abc.ABCMeta):
         if cmd in self.dealer_cmds:
             self.dealer_cmds[cmd](args=msg)
         else:
-            logging.warning('Ununderstood command from broker : %d'
-                            % int.from_bytes(cmd, 'little'))
+            logging.warning('Ununderstood command from broker : {0:d}'.format(int.from_bytes(cmd, 'little')))
 
     def reg_ok(self, args):
         """
@@ -294,12 +292,12 @@ class Broker(object, metaclass=abc.ABCMeta):
                     if 'tcp' in url:
                         port = url.split(':')[-1]
                         pubport = int(port)
-                        self.sub_northurl = self.dealerurl.replace(dealerport, "%d" % pubport)
+                        self.sub_northurl = self.dealerurl.replace(dealerport, "{0:d}".format(pubport))
                 for url in suburls:
                     if 'tcp' in url:
                         port = url.split(':')[-1]
                         subport = int(port)
-                        self.pub_northurl = self.dealerurl.replace(dealerport, "%d" % subport)
+                        self.pub_northurl = self.dealerurl.replace(dealerport, "{0:d}".format(subport))
 
             elif 'ipc' in deal:
                 #logging.debug("IPC: ", deal.split('/')[-1])
@@ -405,7 +403,7 @@ class Broker(object, metaclass=abc.ABCMeta):
             else:
                 self.topic_north[topic] = subs
         else:
-            logging.warning("Unsubscribe from unknown topic: %s" % topic)
+            logging.warning("Unsubscribe from unknown topic: {0!s}".format(topic))
         self.debug_topics()
 
     def add_sub_north(self, topic):
@@ -434,7 +432,7 @@ class Broker(object, metaclass=abc.ABCMeta):
             else:
                 self.topic_south[topic] = subs
         else:
-            logging.warning("Unsubscribe from unknown topic: %s" % topic)
+            logging.warning("Unsubscribe from unknown topic: {0!s}".format(topic))
         self.debug_topics()
 
     def add_sub_south(self, topic):
@@ -510,7 +508,7 @@ class Broker(object, metaclass=abc.ABCMeta):
                 self.router.send_multipart(
                     [client, DD.bPROTO_VERSION, DD.bCMD_PUB, source, topic.encode(), message])
         except BaseException as e:
-            logging.error("Exception in on_sub_north_msg: " % str(e))
+            logging.error("Exception in on_sub_north_msg: ".format(*str(e)))
             pass
 
     #
@@ -530,10 +528,10 @@ class Broker(object, metaclass=abc.ABCMeta):
         body = a[1:]
 
         if cmd == 1:
-            logging.info(" + Got subscription for: %s" % str(body))
+            logging.info(" + Got subscription for: {0!s}".format(str(body)))
             self.add_sub_north(body)
         if cmd == 0:
-            logging.info(" - Got unsubscription for: %s" % str(body))
+            logging.info(" - Got unsubscription for: {0!s}".format(str(body)))
             self.remove_sub_north(body)
         # subscriptions from north should continue down
         self.sub_south_sock.send_multipart(msg)
@@ -573,7 +571,7 @@ class Broker(object, metaclass=abc.ABCMeta):
                     self.router.send_multipart(
                         [client, DD.bPROTO_VERSION, DD.bCMD_PUB, source, topic.encode(), message])
             except BaseException as e:
-                logging.error("Exception in on_sub_south_msg: %s" % str(e))
+                logging.error("Exception in on_sub_south_msg: {0!s}".format(str(e)))
                 pass
 
     def on_pub_south_msg(self, msg):
@@ -590,10 +588,10 @@ class Broker(object, metaclass=abc.ABCMeta):
         body = a[1:]
 
         if cmd == 1:
-            logging.info(" + Got subscription for: %s" % str(body))
+            logging.info(" + Got subscription for: {0!s}".format(str(body)))
             self.add_sub_south(body)
         if cmd == 0:
-            logging.info(" - Got unsubscription for: %s" % str(body))
+            logging.info(" - Got unsubscription for: {0!s}".format(str(body)))
             self.remove_sub_south(body)
 
         self.sub_north_sock.send_multipart(msg)
@@ -645,7 +643,7 @@ class Broker(object, metaclass=abc.ABCMeta):
             if source + R in self.registered_client:
                 r = self.local_cli[source][1]
         except KeyError:
-            logging.warning("Got unsub from unknown source %s" % str(source))
+            logging.warning("Got unsub from unknown source {0!s}".format(str(source)))
             return
 
         #print("START subscrioptions: ")
@@ -656,7 +654,7 @@ class Broker(object, metaclass=abc.ABCMeta):
         #pprint(self.topics_trie)
 
         topic = '.'.join([r, topic.decode()])
-        logging.info(" - Got unsubscription for: %s from %s" % (str(topic),source))
+        logging.info(" - Got unsubscription for: {0!s} from {1!s}".format(str(topic), source))
 
 
        # print("scopestr: ", scopestr)
@@ -762,7 +760,7 @@ class Broker(object, metaclass=abc.ABCMeta):
         dist = args.pop(0)
         if name not in self.dist_cli:
             self.dist_cli[name] = [source, dist]
-            logging.info(' + Added distant client: %s (%s)' % (name, dist))
+            logging.info(' + Added distant client: {0!s} ({1!s})'.format(name, dist))
 
         if self.state == DD.S_REGISTERED:
             self.add_client_up(name, int(dist))
@@ -778,7 +776,7 @@ class Broker(object, metaclass=abc.ABCMeta):
         # TODO: should do authentication here too!
 
         if source not in self.local_br:
-            logging.info(' + Added broker: %s' % str(source))
+            logging.info(' + Added broker: {0!s}'.format(str(source)))
             self.local_br[source] = [0]
 
         self.router.send_multipart([source, DD.bPROTO_VERSION, DD.bCMD_REGOK,
@@ -809,7 +807,7 @@ class Broker(object, metaclass=abc.ABCMeta):
             return
         name = args.pop(0)
         if name in self.dist_cli and self.dist_cli[name][0] == broker:
-            logging.info(' - Deleting distant client: %s' % str(name))
+            logging.info(' - Deleting distant client: {0!s}'.format(str(name)))
             del self.dist_cli[name]
             self.del_cli_up(name)
 
@@ -820,7 +818,7 @@ class Broker(object, metaclass=abc.ABCMeta):
         :param args:
         """
         tmp_to_del = []
-        logging.info(' - Unregistering broker: %s' % str(name))
+        logging.info(' - Unregistering broker: {0!s}'.format(str(name)))
         for cli in self.dist_cli:
             if self.dist_cli[cli][0] == name:
                 tmp_to_del.append(cli)
@@ -842,7 +840,7 @@ class Broker(object, metaclass=abc.ABCMeta):
         elif identity in self.local_br:
             self.router.send_multipart([identity, DD.bPROTO_VERSION, DD.bCMD_PONG])
         else:
-            logging.warning("Ping from unregistered client/broker: %s" % str(identity))
+            logging.warning("Ping from unregistered client/broker: {0!s}".format(str(identity)))
 
     # plain text message from local to another client
     @abc.abstractmethod
@@ -1086,7 +1084,7 @@ class BrokerSafe(Broker):
         try:
             f = open(self.keys)
         except:
-            logging.critical("Could not open keyfile: %s" % self.keys)
+            logging.critical("Could not open keyfile: {0!s}".format(self.keys))
             sys.exit(1)
 
         self.hashes = json.load(f)
@@ -1166,11 +1164,11 @@ class BrokerSafe(Broker):
                 self.reverse_local_cli[prefix_clientname] = [identity, 0]
                 self.registered_client.add(identity + decryptednumber)
                 self.router.send_multipart([identity, DD.bPROTO_VERSION, DD.bCMD_REGOK, decryptednumber])
-                logging.info(' + Added local client :%s' % str(prefix_clientname))
+                logging.info(' + Added local client :{0!s}'.format(str(prefix_clientname)))
                 if self.state == DD.S_REGISTERED:
                     self.add_client_up(prefix_clientname, 0)
             else:
-                logging.warning("%s:  : Authentication failed" % str(clientname))
+                logging.warning("{0!s}:  : Authentication failed".format(str(clientname)))
                 msg = "Authentication failed"
                 self.router.send_multipart(
                     [identity, DD.bPROTO_VERSION, DD.bCMD_DATAPT, self.name, msg.encode()])
@@ -1191,7 +1189,7 @@ class BrokerSafe(Broker):
         topic = msg[0].decode()
 
         if source + cookie not in self.registered_client:
-            logging.warning("Unregisterd source %s trying to publish"%(source+cookie))
+            logging.warning("Unregisterd source {0!s} trying to publish".format((source+cookie)))
             return
 
         name, tenant = self.local_cli[source]
@@ -1238,7 +1236,7 @@ class BrokerSafe(Broker):
                     self.router.send_multipart(
                         [client, DD.bPROTO_VERSION, DD.bCMD_PUB, name, topic_simple.encode(), message])
             except BaseException as e:
-                logging.error("Exception in pub: %s" % str(e))
+                logging.error("Exception in pub: {0!s}".format(str(e)))
                 pass
 
 
@@ -1257,7 +1255,7 @@ class BrokerSafe(Broker):
         scopestr = msg.pop(0).decode()
         # check that client is allowed to publish
         if source + cookie not in self.registered_client:
-            logging.warning("unregistered client %s trying to subscribe!"%(source+cookie))
+            logging.warning("unregistered client {0!s} trying to subscribe!".format((source+cookie)))
             return
 
         tenant = self.local_cli[source][1]
@@ -1327,7 +1325,7 @@ class BrokerSafe(Broker):
             self.sub_north_sock.send_multipart([msg])
             self.sub_south_sock.send_multipart([msg])
 
-        logging.info(" + Added subscription for: %s" % str(topic))
+        logging.info(" + Added subscription for: {0!s}".format(str(topic)))
 
 #            print("new: ", new)
 #            print("END subscrioptions: ")
@@ -1348,7 +1346,7 @@ class BrokerSafe(Broker):
         source = msg.pop(0)
         tmp = msg.pop(0)
         if tmp != DD.bPROTO_VERSION:
-            logging.warning('Different protocols in use, message from: %s' % str(source))
+            logging.warning('Different protocols in use, message from: {0!s}'.format(str(source)))
             return
 
         cmd = msg.pop(0)
@@ -1363,8 +1361,7 @@ class BrokerSafe(Broker):
             f = self.router_cmds[cmd]
             f(source, msg)
         else:
-            logging.warning('Ununderstood command from %s: %d'
-                            % (str(source), int.from_bytes(cmd, 'little')))
+            logging.warning('Ununderstood command from {0!s}: {1:d}'.format(str(source), int.from_bytes(cmd, 'little')))
 
     def unreg_cli(self, identity, args):
         """
@@ -1376,7 +1373,7 @@ class BrokerSafe(Broker):
             cust = args[0].decode()
             name = args[1].decode()
             prefix_name = '.'.join([cust, name]).encode()
-            logging.info(' - Deleting local client %s' % str(prefix_name))
+            logging.info(' - Deleting local client {0!s}'.format(str(prefix_name)))
             if identity in self.local_cli_timeout:
                 del self.local_cli_timeout[identity]
             if identity in self.local_cli:
@@ -1486,7 +1483,7 @@ class BrokerSafe(Broker):
         dst_name = args.pop(0).decode()
         # check if the client is registered
         if source + cookie not in self.registered_client:
-            logging.warning("Unregistered client %s trynig to send"%(source+cookie))
+            logging.warning("Unregistered client {0!s} trynig to send".format((source+cookie)))
             return
         # check if source / destination is public
         source_name, tenant = self.local_cli[source]
@@ -1741,8 +1738,7 @@ class BrokerUnsafe(Broker):
         :return: None
         """
         if name in self.local_cli:
-            logging.info('%s asked for registration but is already registered'
-                         % name)
+            logging.info('{0!s} asked for registration but is already registered'.format(name))
             return
 
         hashval = args.pop(0).decode()
@@ -1751,7 +1747,7 @@ class BrokerUnsafe(Broker):
             short_name = args.pop(0).decode()
             self.local_cli[name] = [0, customer, short_name]
             self.router.send_multipart([name, DD.bPROTO_VERSION, DD.bCMD_REGOK])
-            logging.info(' + Added local client : %s' % name)
+            logging.info(' + Added local client : {0!s}'.format(name))
             if self.state == DD.S_REGISTERED:
                 self.add_client_up(name, 0)
         else:
@@ -1808,7 +1804,7 @@ class BrokerUnsafe(Broker):
                     self.router.send_multipart(
                         [client, DD.bPROTO_VERSION, DD.bCMD_PUB, source_name, topic_simple.encode(), message])
             except BaseException as e:
-                logging.critical("Exception in on_subS_msg: %s" % str(e))
+                logging.critical("Exception in on_subS_msg: {0!s}".format(str(e)))
                 pass
 
     def sub(self, source, msg):
@@ -1857,7 +1853,7 @@ class BrokerUnsafe(Broker):
         else:
             self.topics_trie[topic.decode()] = [source]
 
-        logging.info("Got subscription for: %s" % str(topic))
+        logging.info("Got subscription for: {0!s}".format(str(topic)))
         self.add_sub_south(topic)
         # On_pub_msg should receive a message like : [b'CmdTopic'], where Cmd=\x01 for a sub
         msg = b'\x01' + topic
@@ -1881,15 +1877,14 @@ class BrokerUnsafe(Broker):
 
         tmp = msg.pop(0)
         if tmp != DD.bPROTO_VERSION:
-            logging.warning('Different protocols in use, message from: %s' % str(source))
+            logging.warning('Different protocols in use, message from: {0!s}'.format(str(source)))
             return
         cmd = msg.pop(0)
         if cmd in self.router_cmds:
             f = self.router_cmds[cmd]
             f(source, msg)
         else:
-            logging.warning('Ununderstood command from %s : %d'
-                            % (str(source), int.from_bytes(cmd, 'little')))
+            logging.warning('Ununderstood command from {0!s} : {1:d}'.format(str(source), int.from_bytes(cmd, 'little')))
 
     def unreg_cli(self, name, args):
         """
@@ -1899,7 +1894,7 @@ class BrokerUnsafe(Broker):
         :param args: Frames following the command in the original message
         """
         if name in self.local_cli:
-            logging.info(' - Deleting local client %s' % str(name))
+            logging.info(' - Deleting local client {0!s}'.format(str(name)))
             if name in self.subscriptions:
                 for topic in self.subscriptions[name]:
                     if self.topic_south[topic] == 1:
@@ -1947,7 +1942,7 @@ class BrokerUnsafe(Broker):
         """
         if len(args) < 1:
             return
-        logging.info("Send: source: %s, args: %s" % (source, args))
+        logging.info("Send: source: {0!s}, args: {1!s}".format(source, args))
         customer = self.local_cli[source][1]
         source_name = self.local_cli[source][2].encode()
         is_public = int.from_bytes(args.pop(0), byteorder='little')
@@ -2116,7 +2111,7 @@ if '__main__' == __name__:
     args_list = parser.parse_args()
     numeric_level = getattr(logging, args_list.loglevel.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError('Invalid log level: %s' % args_list.loglevel)
+        raise ValueError('Invalid log level: {0!s}'.format(args_list.loglevel))
 
     if args_list.verbose:
         logging.warning("Verbose option is deprecated, use loglevel instead")

--- a/doubledecker/clientSafe.py
+++ b/doubledecker/clientSafe.py
@@ -358,7 +358,7 @@ class ClientSafe(interface.Client):
         elif cmd == DD.bCMD_SUBOK:
             topic = msg.pop(0).decode()
             scope = msg.pop(0).decode()
-            tt = "%s%s" % (topic, scope)
+            tt = "{0!s}{1!s}".format(topic, scope)
             if tt not in self._sublist:
                 self._sublist.append(tt)
             else:

--- a/doubledecker/clientUnsafe.py
+++ b/doubledecker/clientUnsafe.py
@@ -32,8 +32,7 @@ class ClientUnsafe(interface.Client):
                 return
             dst = cmd[1].encode("utf8")
             msg = cmd[2].strip().encode('utf8')
-            logging.debug("Sending \"%s\" to %s" %
-                          (msg, dst.decode('utf8')))
+            logging.debug("Sending \"{0!s}\" to {1!s}".format(msg, dst.decode('utf8')))
             self.sendmsg(dst, msg)
         elif 'exit' == cmd[0]:
             self.shutdown()
@@ -46,19 +45,19 @@ class ClientUnsafe(interface.Client):
         elif 'unsub' == cmd[0]:
             if len(cmd) > 1:
                 if (cmd[1] in self._sublist):
-                    logging.info("Unsubscribing from %s*" % cmd[1])
+                    logging.info("Unsubscribing from {0!s}*".format(cmd[1]))
                     for sub in self._sublist:
                         if(sub.startswith(cmd[1]+"/")):
                             self._dealer.send_multipart([DD.bPROTO_VERSION, DD.bCMD_UNSUB, sub.encode()])
                             self._sublist.remove(sub)
 
                 else:
-                    logging.info("You are not subscribed to this topic: %s" % cmd[1])
+                    logging.info("You are not subscribed to this topic: {0!s}".format(cmd[1]))
             else:
                 print("usage: unsub [topic]")
         elif 'pub' == cmd[0]:
             if len(cmd) > 2:
-                logging.info("Publishing message on %s*" % cmd[1])
+                logging.info("Publishing message on {0!s}*".format(cmd[1]))
                 self.publish(cmd[1].encode(), cmd[2].encode())
             else:
                 print("usage: pub [topic] [message]")
@@ -87,9 +86,9 @@ class ClientUnsafe(interface.Client):
             print("The scope should be like: '/1/2/3/'")
             return
         if scopestr == "noscope":
-            logging.info("Subscribing to %s" % topic)
+            logging.info("Subscribing to {0!s}".format(topic))
         else:
-            logging.info("Subscribing to %s" % (topic + scopestr))
+            logging.info("Subscribing to {0!s}".format((topic + scopestr)))
         self._send(DD.bCMD_SUB, [topic.encode(), scopestr.encode()])
 
     def publish(self, topic, message):
@@ -191,7 +190,7 @@ class ClientUnsafe(interface.Client):
         elif cmd == DD.bCMD_SUBOK:
             topic = msg.pop(0).decode()
             scope = msg.pop(0).decode()
-            tt = "%s%s" % (topic, scope)
+            tt = "{0!s}{1!s}".format(topic, scope)
             if tt not in self._sublist:
                 self._sublist.append(tt)
             else:
@@ -200,9 +199,9 @@ class ClientUnsafe(interface.Client):
                     [DD.bPROTO_VERSION,
                      DD.bCMD_UNSUB, topic.encode()])
         elif cmd == DD.bCMD_NODST:
-            logging.warning("Unknown client %s" % msg.pop(0))
+            logging.warning("Unknown client {0!s}".format(msg.pop(0)))
         else:
-            logging.warning("Unknown command, got: %d %s" % (cmd, msg))
+            logging.warning("Unknown command, got: {0:d} {1!s}".format(cmd, msg))
 
     def _cli_usage(self):
         print("Commands: ")

--- a/doubledecker/generatekeys.py
+++ b/doubledecker/generatekeys.py
@@ -121,7 +121,7 @@ def generateKeys(names):
     f.write(json.dumps(publicClientKeyList, indent=4) .encode('utf8'))
     f.close()
     for key in customerKeys:
-        f = open("%s-keys.json" % key['name'], "wb")
+        f = open("{0!s}-keys.json".format(key['name']), "wb")
         del key['name']
         f.write(json.dumps(key, indent=4).encode('utf8'))
         f.close()

--- a/doubledecker/trie.py
+++ b/doubledecker/trie.py
@@ -562,13 +562,13 @@ class Trie(collections.MutableMapping):
     return self._root != other._root  # pylint: disable=protected-access
 
   def __str__(self):
-    return 'Trie(%s)' % (
-        ', '.join('%s: %s' % item for item in self.iteritems()))
+    return 'Trie({0!s})'.format((
+        ', '.join('{0!s}: {1!s}'.format(*item) for item in self.iteritems())))
 
   def __repr__(self):
     if self:
-      return  'Trie((%s,))' % (
-          ', '.join('(%r, %r)' % item for item in self.iteritems()))
+      return  'Trie(({0!s},))'.format((
+          ', '.join('({0!r}, {1!r})'.format(*item) for item in self.iteritems())))
     else:
       return 'Trie()'
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Acreo:DoubleDecker-py?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:Acreo:DoubleDecker-py?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
